### PR TITLE
chore(graphql): Remove deprecated property from entitySearchQueries

### DIFF
--- a/nerdlets/shared/services/queries.js
+++ b/nerdlets/shared/services/queries.js
@@ -12,7 +12,6 @@ query ($accountId: Int!) {
           }
           entitySearchQueries {
             id
-            name
             query
             updatedAt
             createdAt


### PR DESCRIPTION
The property `name` is deprecated and would be removed soon.
I did not find any usage in your code, so just deleting it from the GraphQL query