### PR TITLE
Fix/provide better entity association warning

### DIFF
--- a/nerdlets/geo-ops-nerdlet/ViewMap.js
+++ b/nerdlets/geo-ops-nerdlet/ViewMap.js
@@ -583,22 +583,32 @@ export default class ViewMap extends React.PureComponent {
                       )}
                       {hasMapLocations && !hasEntities && (
                         <>
-                          <MapLocationTable
-                            data={mapLocations}
-                            map={map}
-                            rowClickHandler={this.handleTableRowClick}
-                            activeMapLocation={activeMapLocation}
-                          />
-                          <EmptyState
-                            heading="Map locations but no associated entities"
-                            description=""
-                            buttonText="Configure your Map"
-                            buttonOnClick={() =>
+                          <div
+                            className="alert-warning"
+                            onClick={() =>
                               navigation.router({
                                 to: 'createMap',
                                 state: { selectedMap: map, activeStep: 1 }
                               })
                             }
+                          >
+                            <Icon
+                              type={
+                                Icon.TYPE
+                                  .INTERFACE__SIGN__EXCLAMATION__V_ALTERNATE
+                              }
+                              color="#8c732a"
+                            />
+                            <p>
+                              Your map locations have not yet been associated
+                              with entities. <a href="#">Resolve this</a>
+                            </p>
+                          </div>
+                          <MapLocationTable
+                            data={mapLocations}
+                            map={map}
+                            rowClickHandler={this.handleTableRowClick}
+                            activeMapLocation={activeMapLocation}
                           />
                         </>
                       )}

--- a/nerdlets/geo-ops-nerdlet/ViewMap.scss
+++ b/nerdlets/geo-ops-nerdlet/ViewMap.scss
@@ -291,3 +291,32 @@ a:not(.u-unstyledLink):not(.AABQAC-wnd-Link--external).leaflet-control-zoom-out 
 .children-container [class*='TabContent'].entity-summary-tab {
     padding: 8px 16px;
 }
+
+.alert-warning {
+    display: flex;
+    align-items: center;
+    background-color: #fff7df;
+    color: #8c732a;
+    padding: 12px 16px 10px;
+    border-bottom: 1px solid #f5edd6;
+
+    &:hover {
+        cursor: pointer;
+    }
+
+    .ic-Icon {
+        margin-right: 10px;
+    }
+
+    p {
+        margin: 0;
+        color: #8c732a;
+        font-size: 13px;
+        line-height: 18px;
+
+        a {
+            color: #8c732a;
+            text-decoration: underline;
+        }
+    }
+}

--- a/nerdlets/geo-ops-nerdlet/ViewMap.scss
+++ b/nerdlets/geo-ops-nerdlet/ViewMap.scss
@@ -311,7 +311,7 @@ a:not(.u-unstyledLink):not(.AABQAC-wnd-Link--external).leaflet-control-zoom-out 
     p {
         margin: 0;
         color: #8c732a;
-        font-size: 13px;
+        font-size: 12px;
         line-height: 18px;
 
         a {


### PR DESCRIPTION
When the locations provided for a map haven't been associated with entities yet, we showed an empty state but it wasn't really visible because the table was often too full. Now, we instead show a readable error above the table explaining what's wrong. Here's a preview of that error:

<img width="572" alt="Captura de Pantalla 2020-04-15 a la(s) 2 20 15 p  m" src="https://user-images.githubusercontent.com/812989/79373105-3d2b0080-7f24-11ea-9236-d729a25d1ea4.png">

