### PR TITLE
fix: bumps app version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "opensource+nr1-workload-geoops@newrelic.com"
   },
   "description": "New Relic One application aligning Workloads and Entities to geographic data (ex. Point of Sale monitoring).",
-  "version": "1.5.5",
+  "version": "1.5.4",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "test": "jest",


### PR DESCRIPTION
This PR uses a conventional `fix` commit message to correctly bump the app version, by changing the manually modify app version back to 1.5.4